### PR TITLE
Update the number of supported SSL versions

### DIFF
--- a/doc/tclcurl.n
+++ b/doc/tclcurl.n
@@ -1639,7 +1639,7 @@ The default action. This will attempt to figure out the remote SSL protocol vers
 i.e. either SSLv3 or TLSv1 (but not SSLv2, which became disabled by default with 7.18.1). 
 .TP
 .B tlsv1
-Force TLSv1
+Force TLSv1 or later
 .TP
 .B sslv2
 Force SSLv2
@@ -1648,13 +1648,31 @@ Force SSLv2
 Force SSLv3
 .TP
 .B tlsv1_0
-Force TLSv1.0
+Force TLSv1.0 or later
 .TP
 .B tlsv1_1
-Force TLSv1.1
+Force TLSv1.1 or later
 .TP
 .B tlsv1_2
-Force TLSv1.2
+Force TLSv1.2 or later
+.TP
+.B tlsv1_3
+Force TLSv1.3 or later
+.TP
+.B maxdefault
+Use the maximum supported TLS version by libcurl or the default value from the SSL library.
+.TP
+.B maxtlsv1_0
+Define maximum supported TLS version as TLSv1.0
+.TP
+.B maxtlsv1_1
+Define maximum supported TLS version as TLSv1.1
+.TP
+.B maxtlsv1_2
+Define maximum supported TLS version as TLSv1.2
+.TP
+.B maxtlsv1_3
+Define maximum supported TLS version as TLSv1.3
 .RE
 
 .TP

--- a/generic/tclcurl.c
+++ b/generic/tclcurl.c
@@ -880,6 +880,24 @@ curlSetOpts(Tcl_Interp *interp, struct curlObjData *curlData,
                     break;
                 case 6:
                     longNumber=CURL_SSLVERSION_TLSv1_2;
+                    break;
+                case 7:
+                    longNumber=CURL_SSLVERSION_TLSv1_3;
+                    break;
+                case 8:
+                    longNumber=CURL_SSLVERSION_MAX_DEFAULT;
+                    break;
+                case 9:
+                    longNumber=CURL_SSLVERSION_MAX_TLSv1_0;
+                    break;
+                case 10:
+                    longNumber=CURL_SSLVERSION_MAX_TLSv1_1;
+                    break;
+                case 11:
+                    longNumber=CURL_SSLVERSION_MAX_TLSv1_2;
+                    break;
+                case 12:
+                    longNumber=CURL_SSLVERSION_MAX_TLSv1_3;
             }
             tmpObjPtr=Tcl_NewLongObj(longNumber);
             if (SetoptLong(interp,curlHandle,CURLOPT_SSLVERSION,

--- a/generic/tclcurl.h
+++ b/generic/tclcurl.h
@@ -350,7 +350,8 @@ CONST static char *ftpsslccc[] = {
 };
 
 CONST static char *sslversion[] = {
-    "default", "tlsv1", "sslv2", "sslv3", "tlsv1_0", "tlsv1_1", "tlsv1_2", (char *)NULL
+    "default", "tlsv1", "sslv2", "sslv3", "tlsv1_0", "tlsv1_1", "tlsv1_2", "tlsv1_3",
+    "maxdefault", "maxtlsv1_0", "maxtlsv1_1", "maxtlsv1_2", "maxtlsv1_3", (char *)NULL
 };
 
 CONST static char *ftpfilemethod[] = {


### PR DESCRIPTION
This updates the -sslversion config option including support for TLS v1.3 . At least libcurl 7.54.0 is required.