### PR TITLE
Support sslversionandmax argument

### DIFF
--- a/doc/tclcurl.n
+++ b/doc/tclcurl.n
@@ -1673,6 +1673,10 @@ Define maximum supported TLS version as TLSv1.3
 .RE
 
 .TP
+.B -sslversionandmax
+Provide a 2 item list of sslversion and ssl max version. This is to use both items at the same time. 
+
+.TP
 .B -sslverifypeer
 This option determines whether TclCurl verifies the authenticity of the peer's certificate.
 A 1 means it verifies; zero means it doesn't. The default is 1. 

--- a/generic/tclcurl.c
+++ b/generic/tclcurl.c
@@ -455,6 +455,7 @@ curlSetOpts(Tcl_Interp *interp, struct curlObjData *curlData,
 
     Tcl_Obj                 **httpPostData;
     Tcl_Obj                 **protocols;
+    Tcl_Obj                 **sslversionandmax;
     int                       curlTableIndex,formaddError,formArrayIndex;
     struct formArrayStruct   *newFormArray;
     struct curl_forms        *formArray;
@@ -462,6 +463,7 @@ curlSetOpts(Tcl_Interp *interp, struct curlObjData *curlData,
     size_t                    contentslen;
 
     unsigned long int         protocolMask;
+    unsigned long int         sslversionMask;
 
     switch(tableIndex) {
         case 0:
@@ -2180,6 +2182,73 @@ curlSetOpts(Tcl_Interp *interp, struct curlObjData *curlData,
                 return TCL_ERROR;
             }
             return TCL_OK;
+            break;
+        case 175:
+            if (Tcl_ListObjGetElements(interp,objv,&j,&sslversionandmax)==TCL_ERROR) {
+                return 1;
+            }
+            if (j!=2) {
+                curlErrorSetOpt(interp,configTable,tableIndex,"sslversionandmax requires a 2 element list");
+                return TCL_ERROR;
+            }
+
+            
+            sslversionMask=0;
+            if (Tcl_GetIndexFromObj(interp,sslversionandmax[0],sslversionnomax,
+                    "sslversionnomax",TCL_EXACT,&curlTableIndex)==TCL_ERROR) {
+                return TCL_ERROR;
+            }
+            switch(curlTableIndex) {
+                case 0:
+                    sslversionMask|=CURL_SSLVERSION_DEFAULT;
+                    break;
+                case 1:
+                    sslversionMask|=CURL_SSLVERSION_TLSv1;
+                    break;
+                case 2:
+                    sslversionMask|=CURL_SSLVERSION_SSLv2;
+                    break;
+                case 3:
+                    sslversionMask|=CURL_SSLVERSION_SSLv3;
+                    break;
+                case 4:
+                    sslversionMask|=CURL_SSLVERSION_TLSv1_0;
+                    break;
+                case 5:
+                    sslversionMask|=CURL_SSLVERSION_TLSv1_1;
+                    break;
+                case 6:
+                    sslversionMask|=CURL_SSLVERSION_TLSv1_2;
+                    break;
+                case 7:
+                    sslversionMask|=CURL_SSLVERSION_TLSv1_3;
+            }
+
+            if (Tcl_GetIndexFromObj(interp,sslversionandmax[1],sslversionmax,
+                    "sslversionmax",TCL_EXACT,&curlTableIndex)==TCL_ERROR) {
+                return TCL_ERROR;
+            }
+            switch(curlTableIndex) {
+                case 0:
+                    sslversionMask|=CURL_SSLVERSION_MAX_DEFAULT;
+                    break;
+                case 1:
+                    sslversionMask|=CURL_SSLVERSION_MAX_TLSv1_0;
+                    break;
+                case 2:
+                    sslversionMask|=CURL_SSLVERSION_MAX_TLSv1_1;
+                    break;
+                case 3:
+                    sslversionMask|=CURL_SSLVERSION_MAX_TLSv1_2;
+                    break;
+                case 4:
+                    sslversionMask|=CURL_SSLVERSION_MAX_TLSv1_3;
+            }
+
+            tmpObjPtr=Tcl_NewLongObj(sslversionMask);
+            if (SetoptLong(interp,curlHandle,CURLOPT_SSLVERSION,tableIndex,tmpObjPtr)) {
+                    return TCL_ERROR;
+            }
             break;
     }
     return TCL_OK;

--- a/generic/tclcurl.h
+++ b/generic/tclcurl.h
@@ -263,7 +263,7 @@ CONST static char *configTable[] = {
     "-fnmatchproc",       "-resolve",            "-tlsauthusername",
     "-tlsauthpassword",   "-tlsauthtype",        "-transferencoding",
     "-gssapidelegation",  "-noproxy",            "-telnetoptions",
-    (char *) NULL
+    "-sslversionandmax", (char *) NULL
 };
 
 CONST static char    *timeCond[] = {
@@ -351,6 +351,14 @@ CONST static char *ftpsslccc[] = {
 
 CONST static char *sslversion[] = {
     "default", "tlsv1", "sslv2", "sslv3", "tlsv1_0", "tlsv1_1", "tlsv1_2", "tlsv1_3",
+    "maxdefault", "maxtlsv1_0", "maxtlsv1_1", "maxtlsv1_2", "maxtlsv1_3", (char *)NULL
+};
+
+CONST static char *sslversionnomax[] = {
+    "default", "tlsv1", "sslv2", "sslv3", "tlsv1_0", "tlsv1_1", "tlsv1_2", "tlsv1_3", (char *)NULL
+};
+
+CONST static char *sslversionmax[] = {
     "maxdefault", "maxtlsv1_0", "maxtlsv1_1", "maxtlsv1_2", "maxtlsv1_3", (char *)NULL
 };
 


### PR DESCRIPTION
I was looking to specifying a TLS version (basically a minimum TLS version in newer versions of curl) with a max TLS version (-tls-max option in curl). tclcurl supports using 1 or the other inside of the -sslversion option. It is not possible to set both at once with this option. This option sets CURLOPT_SSLVERSION. Unfortunately, libcurl does not support setting the max TLS version in its own option, so it isn't easy to just add another tclcurl option to set this.

https://curl.se/libcurl/c/CURLOPT_SSLVERSION.html

Curl allows us to set both at the same time with a bitwise or operation. I have tested some local changes with adding an option -sslversionandmax to take a 2 element list. 