### PR TITLE
Workflow Fixes

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -16,11 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew update
-        brew install tcl-tk autoconf curl
+        brew install tcl-tk@8 autoconf curl
+        brew link tcl-tk@8
     - name: configure
       run: |       
         autoreconf -vi
-        ./configure --with-tcl=/opt/homebrew/opt/tcl-tk/lib --prefix=/usr/local        
+        ./configure --with-tcl=/opt/homebrew/lib --prefix=/usr/local
     - name: make
       run: make
     - name: install

--- a/tests/versionInfo.test
+++ b/tests/versionInfo.test
@@ -30,7 +30,7 @@ test 1.05 {: Test that -sslversionnum returns something} -body {
 
 test 1.06 {: Test that -libzversion returns something} -body {
 	return [curl::versioninfo -libzversion]
-} -match regexp -result {^\d+\.\d+\.\d+$}
+} -match regexp -result {^\d+\.\d+(\.\d+)?$}
 
 test 1.07 {: Test that -protocols returns something} -body {
 	return [curl::versioninfo -protocols]


### PR DESCRIPTION
On Linux, the tests fail because the libz version number for libz now only has 2 components instead of 3. The 3rd component is optional now.
On Mac, homebrew switched to Tcl 9. That means that "CONST" isn't defined anymore which makes the build break. So I pinned Tcl to version 8 as that's what the other platforms are using.